### PR TITLE
Hide homepage quick-facts panel from visual UI while preserving crawlable content

### DIFF
--- a/src/components/AEOContent.tsx
+++ b/src/components/AEOContent.tsx
@@ -44,23 +44,20 @@ export default function AEOContent() {
         dangerouslySetInnerHTML={{ __html: JSON.stringify(faqSchema) }}
       />
 
-      <section aria-labelledby="quick-facts-heading" className="mx-auto mt-16 max-w-6xl px-4 sm:px-6 lg:px-8">
-        <div className="rounded-2xl border border-lightText/10 bg-primary/5 p-6 md:p-8">
-          <h2 id="quick-facts-heading" className="text-2xl font-semibold text-lightText">
-            Quick facts for collaborators and AI assistants
-          </h2>
-          <p className="mt-3 max-w-3xl text-lightText/80">
-            This section summarizes expertise, location, and collaboration information in a concise format that is easy to read for both visitors and answer engines.
-          </p>
-          <dl className="mt-6 grid gap-4 md:grid-cols-2">
-            {faqItems.map((item) => (
-              <div key={item.question} className="rounded-xl border border-lightText/10 bg-darkBg/50 p-4">
-                <dt className="font-medium text-secondary">{item.question}</dt>
-                <dd className="mt-2 text-sm leading-relaxed text-lightText/80">{item.answer}</dd>
-              </div>
-            ))}
-          </dl>
-        </div>
+      {/* Keep crawlable content available for scrapers/agents while removing it from the visual UI. */}
+      <section aria-hidden="true" className="hidden" data-ai-content="quick-facts">
+        <h2>Quick facts for collaborators and AI assistants</h2>
+        <p>
+          This section summarizes expertise, location, and collaboration information in a concise format that is easy to read for both visitors and answer engines.
+        </p>
+        <dl>
+          {faqItems.map((item) => (
+            <div key={item.question}>
+              <dt>{item.question}</dt>
+              <dd>{item.answer}</dd>
+            </div>
+          ))}
+        </dl>
       </section>
     </>
   );


### PR DESCRIPTION
### Motivation
- Remove the visible "Quick facts for collaborators and AI assistants" panel from the homepage UI while keeping machine-readable access for AI agents and web scrapers.
- Preserve the existing structured data and crawlable profile content so automated tools and search engines retain the same information.

### Description
- Replaced the styled visible panel with a non-visual hidden section in `src/components/AEOContent.tsx` so the content remains in the DOM but is not shown to human visitors.
- Kept the existing FAQ JSON-LD script block unchanged so structured data exposure is preserved for search engines and agents.
- Added `aria-hidden="true"`, `className="hidden"`, and a `data-ai-content="quick-facts"` marker to make the intent explicit and maintain accessibility semantics for assistive tools.
- Left question/answer text intact and rendered in simple markup within the hidden section so scrapers that parse DOM content can still access it.

### Testing
- Ran `npm run lint`, which failed in this environment because `next` is not installed (`sh: 1: next: not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ddf25d94a48330a90ee06286c69608)